### PR TITLE
Validate presence of Snippet#recipient

### DIFF
--- a/lib/bundle_notification/snippet.rb
+++ b/lib/bundle_notification/snippet.rb
@@ -9,6 +9,8 @@ module BundleNotification
 
     serialize :data, Serializer
 
+    validates :recipient, presence: true
+
     scope :unsent_for, ->(mailer_class) { where(mailer_class: mailer_class, sent_at: nil) }
   end
 end

--- a/spec/bundle_notification/snippet_spec.rb
+++ b/spec/bundle_notification/snippet_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 RSpec.describe BundleNotification::Snippet do
   it 'serializes and de-serializes the `data` attribute' do
-    described_class.create!(data: { foo: 'bar' })
+    create(:snippet, data: { foo: 'bar' })
     expect(described_class.last.data).to eq(foo: 'bar')
   end
 
@@ -13,20 +13,26 @@ RSpec.describe BundleNotification::Snippet do
       config.serializer = JSON
     end
 
-    described_class.create!(data: { foo: 'bar' })
+    create(:snippet, data: { foo: 'bar' })
     expect(described_class.last.data).to eq('foo' => 'bar')
     expect(described_class.last.read_attribute_before_type_cast(:data)).to eq('{"foo":"bar"}')
   end
 
   it 'serializes nil values' do
-    described_class.create!(data: nil)
+    create(:snippet, data: nil)
     expect(described_class.last.read_attribute_before_type_cast(:data)).to eq(nil)
     expect(described_class.last.data).to eq(nil)
   end
 
   it 'serializes empty values' do
-    described_class.create!(data: {})
+    create(:snippet, data: {})
     expect(described_class.last.read_attribute_before_type_cast(:data)).to eq("--- {}\n")
     expect(described_class.last.data).to eq({})
+  end
+
+  it 'validates presence of the recipient' do
+    snippet = build(:snippet, recipient: nil)
+    expect(snippet).not_to be_valid
+    expect(snippet.errors.full_messages).to include("Recipient can't be blank")
   end
 end


### PR DESCRIPTION
[When looking up unsent snippets, it groups them by recipient](https://github.com/ad2games/bundle_notification/blob/master/lib/bundle_notification/deliver.rb#L17), which groups all snippets with an empty recipient together. Those are then potentially sent off to additional recipients, if there are any added in the mailer. In order to prevent that, let's validate the presence of a recipient in the snippet.